### PR TITLE
Snakefile: add warmup job to avoid parallel gdml downloads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -17,4 +17,17 @@ rule compile_analysis:
 root -l -b -q -e '.L {input}+'
 """
 
+rule warmup_run:
+    output:
+        "warmup/{DETECTOR_CONFIG}.edm4hep.root",
+    message: "Ensuring that calibrations/fieldmaps are available for {wildcards.DETECTOR_CONFIG}"
+    shell: """
+ddsim \
+  --runType batch \
+  --numberOfEvents 1 \
+  --compactFile "$DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml" \
+  --outputFile "{output}" \
+  --enableGun
+"""
+
 include: "benchmarks/diffractive_vm/Snakefile"

--- a/benchmarks/diffractive_vm/Snakefile
+++ b/benchmarks/diffractive_vm/Snakefile
@@ -40,7 +40,8 @@ ln {input} {output}
 
 rule diffractive_vm_sim:
     input:
-        "input/diffractive_vm/sartre_{PARTICLE}_{INDEX}.hepmc",
+        hepmc="input/diffractive_vm/sartre_{PARTICLE}_{INDEX}.hepmc",
+        warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
         "sim/{DETECTOR_CONFIG}/sartre_{PARTICLE}_{INDEX}.edm4hep.root",
     params:
@@ -54,7 +55,7 @@ ddsim \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
   --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
-  --inputFiles {input} \
+  --inputFiles {input.hepmc} \
   --outputFile {output}
 """
 


### PR DESCRIPTION
This is needed to facilitate running benchmarks where downloads may happen.

https://github.com/eic/epic/pull/588
fails in
https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/jobs/2512243#L327