### PR TITLE
single/analysis: reduce mean track threshold for backward tracking

### DIFF
--- a/benchmarks/single/analysis/analyze.cxx
+++ b/benchmarks/single/analysis/analyze.cxx
@@ -26,8 +26,12 @@ int analyze(std::string file)
 
   auto stats_n_tracks_gen = d.Stats("n_tracks_gen");
   auto stats_n_tracks_rec = d.Stats("n_tracks_rec");
-  if (stats_n_tracks_rec->GetMean() < 0.8) {
-    std::cout << "Error: too few tracks per events " << std::endl;
+  double mean_num_track_thresh = 0.8;
+  if (file.find("135to177deg") != std::string::npos) {
+    mean_num_track_thresh = 0.6;
+  }
+  if (stats_n_tracks_rec->GetMean() < mean_num_track_thresh) {
+    std::cout << "Error: too few tracks per events (" << stats_n_tracks_rec->GetMean() << ")" << std::endl;
     stats_n_tracks_gen->Print();
     stats_n_tracks_rec->Print();
     return -1;


### PR DESCRIPTION
Last time we had to change this in 
https://github.com/eic/physics_benchmarks/commit/cfdbaeabef58c1debfa7260d6a4315c02ba4dce7

This is needed to support reduced efficiency from https://github.com/eic/EICrecon/pull/1383