### PR TITLE
lambda/Snakefile: adjust output paths, don't upload edm4hep files to artifacts

### DIFF
--- a/benchmarks/lambda/Snakefile
+++ b/benchmarks/lambda/Snakefile
@@ -46,7 +46,7 @@ if [[ {wildcards.P} -gt 225 ]]; then
 else
    NEVENTS_REC=1000
 fi
-eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Pdd4hep:xml_files=$DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml -Ppodio:output_include_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits  -Pjana:nevents=$NEVENTS_REC
+eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Pdd4hep:xml_files=$DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml -Ppodio:output_collections=MCParticles,HcalFarForwardZDCClusters,HcalFarForwardZDCRecHits,HcalFarForwardZDCSubcellHits  -Pjana:nevents=$NEVENTS_REC
 """
 
 rule lambda_analysis:

--- a/benchmarks/lambda/Snakefile
+++ b/benchmarks/lambda/Snakefile
@@ -4,7 +4,7 @@ rule lambda_generate:
 	params:
 		NEVENTS_GEN=100000,
 	output:
-		GEN_FILE="results/lambda/lambda_decay_{P}GeV.hepmc"
+		GEN_FILE="sim_output/lambda/lambda_decay_{P}GeV.hepmc"
 	shell:
 		"""
 mkdir -p results/lambda
@@ -13,11 +13,11 @@ root -l -b -q '{input.script}({params.NEVENTS_GEN},0,"{output.GEN_FILE}",{wildca
 
 rule lambda_simulate:
 	input:
-		GEN_FILE="results/lambda/lambda_decay_{P}GeV.hepmc"
+		GEN_FILE="sim_output/lambda/lambda_decay_{P}GeV.hepmc"
 	params:
 		PHYSICS_LIST="FTFP_BERT"
 	output:
-		SIM_FILE="results/lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV.edm4hep.root"
+		SIM_FILE="sim_output/lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV.edm4hep.root"
 	shell:
 		"""
 if [[ {wildcards.P} -gt 225 ]]; then
@@ -36,9 +36,9 @@ npsim \
 
 rule lambda_recon:
         input:
-                SIM_FILE="results/lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV.edm4hep.root"
+                SIM_FILE="sim_output/lambda/{DETECTOR_CONFIG}_sim_lambda_dec_{P}GeV.edm4hep.root"
         output:
-                REC_FILE="results/lambda/{DETECTOR_CONFIG}_rec_lambda_dec_{P}GeV.edm4hep.root"
+                REC_FILE="sim_output/lambda/{DETECTOR_CONFIG}_rec_lambda_dec_{P}GeV.edm4hep.root"
         shell:
                 """
 if [[ {wildcards.P} -gt 225 ]]; then
@@ -51,12 +51,12 @@ eicrecon {input.SIM_FILE} -Ppodio:output_file={output.REC_FILE} -Pdd4hep:xml_fil
 
 rule lambda_analysis:
 	input:
-                expand("results/lambda/{DETECTOR_CONFIG}_rec_lambda_dec_{P}GeV.edm4hep.root",
+                expand("sim_output/lambda/{DETECTOR_CONFIG}_rec_lambda_dec_{P}GeV.edm4hep.root",
 		    P=[100, 125, 150,175, 200, 225, 250, 275],
 		    DETECTOR_CONFIG=["{DETECTOR_CONFIG}"]),
                 script="benchmarks/lambda/analysis/lambda_plots.py",
 	output:
-		results_dir=directory("results/lambda/results_{DETECTOR_CONFIG}_lambda_dec"),
+		results_dir=directory("results/{DETECTOR_CONFIG}/lambda"),
 	shell:
 		"""
 mkdir -p {output.results_dir}

--- a/benchmarks/lambda/analysis/lambda_plots.py
+++ b/benchmarks/lambda/analysis/lambda_plots.py
@@ -18,7 +18,7 @@ import uproot as ur
 arrays_sim={}
 momenta=100, 125, 150, 175,200,225,250,275
 for p in momenta:
-    filename=f'results/lambda/epic_zdc_sipm_on_tile_only_rec_lambda_dec_{p}GeV.edm4hep.root'
+    filename=f'sim_output/lambda/epic_zdc_sipm_on_tile_only_rec_lambda_dec_{p}GeV.edm4hep.root'
     print("opening file", filename)
     events = ur.open(filename+':events')
     arrays_sim[p] = events.arrays()[:-1] #remove last event, which for some reason is blank

--- a/benchmarks/lambda/config.yml
+++ b/benchmarks/lambda/config.yml
@@ -1,4 +1,3 @@
-
 lambda:simulate:
   stage: simulate
   extends: .phy_benchmark
@@ -15,14 +14,21 @@ lambda:simulate:
       - P: 275
   timeout: 6 hours
   script:
-    - snakemake --cores 1 results/lambda/epic_zdc_sipm_on_tile_only_rec_lambda_dec_${P}GeV.edm4hep.root 
+    - snakemake --cores 1 sim_output/lambda/epic_zdc_sipm_on_tile_only_rec_lambda_dec_${P}GeV.edm4hep.root 
   retry:
     max: 2
     when:
       - runner_system_failure
 
-lambda:results:
-  stage: collect
+lambda:analyze:
+  stage: analyze
+  extends: .phy_benchmark
   needs: ["lambda:simulate"]
   script:
-    - python benchmarks/lambda/analysis/lambda_plots.py results/lambda/results_epic_zdc_sipm_on_tile_only_lambda_dec
+    - snakemake --cores 1 results/epic_zdc_sipm_on_tile_only/lambda 
+
+lambda:results:
+  stage: collect
+  needs: ["lambda:analyze"]
+  script:
+    - ls -al


### PR DESCRIPTION
We can not upload lots of large files to artifacts yet, so this moves them to sim_output, which is symlinked to a scratch space
https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench/-/blob/master/share/common.yml?ref_type=heads#L33