### PR TITLE
Don't crash lambda benchmark if gaussian fit on histograms fails

### DIFF
--- a/benchmarks/lambda/analysis/lambda_plots.py
+++ b/benchmarks/lambda/analysis/lambda_plots.py
@@ -202,6 +202,7 @@ plt.ylabel("events")
 plt.sca(axs[2])
 sigmas=[]
 dsigmas=[]
+xvals=[]
 for p in momenta:
     
     accept=(nclusters[p]==3) &(pi0_converged[p])
@@ -214,14 +215,16 @@ for p in momenta:
     p0=(100, 0, 0.06)
     #print(bc[slc],y[slc])
     sigma=np.sqrt(y[slc])+(y[slc]==0)
-    coeff, var_matrix = curve_fit(fnc, list(bc[slc]), list(y[slc]), p0=p0,sigma=list(sigma))
-                                     
-    x=np.linspace(-1, 1)
-    sigmas.append(coeff[2])
-    dsigmas.append(np.sqrt(var_matrix[2][2]))
+    try:
+        coeff, var_matrix = curve_fit(fnc, list(bc[slc]), list(y[slc]), p0=p0,sigma=list(sigma))
+        sigmas.append(coeff[2])
+        dsigmas.append(np.sqrt(var_matrix[2][2]))
+        xvals.append(p)
+    except:
+        print("fit failed")
 plt.ylim(0, 0.3)
 
-plt.errorbar(momenta, sigmas, dsigmas, ls='', marker='o', color='k')
+plt.errorbar(xvals, sigmas, dsigmas, ls='', marker='o', color='k')
 x=np.linspace(100, 275, 100)
 plt.plot(x, 3/np.sqrt(x), color='tab:orange')
 plt.text(170, .23, "YR requirement:\n   3 mrad/$\\sqrt{E}$")


### PR DESCRIPTION
prevent crashing when one of the fits fails

### Briefly, what does this PR introduce?
Prevents the lambda benchmark from crashing if a gaussian fit on certain histograms fail.  Namely, the histograms for  reconstructed - generated polar angle of the lambda, for a given generated momentum of the lambda.  If the statistics are very low (for instance if there's very little efficiency for some momentum range), then this histogram will have very weak statistics and the fit will fail.  

### What kind of change does this PR introduce?
- [X] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [X] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no
### Does this PR change default behavior?
yes.  Prevents crashing for low-statistics histograms in lambda benchmark