### PR TITLE
dis: enable backwards-compatibility with previous versions of EICrecon

### DIFF
--- a/benchmarks/dis/analysis/dis_electrons.cxx
+++ b/benchmarks/dis/analysis/dis_electrons.cxx
@@ -61,6 +61,20 @@ int dis_electrons(const std::string& config_name)
   ROOT::EnableImplicitMT(kNumThreads);
   ROOT::RDataFrame d("events", rec_file);
 
+  std::string esigma_Q2_col_name, esigma_x_col_name;
+  if (d.HasColumn("InclusiveKinematicsESigma.Q2")) {
+    // new style
+    esigma_Q2_col_name = "InclusiveKinematicsESigma.Q2";
+    esigma_x_col_name = "InclusiveKinematicsESigma.Q2";
+  } else if (d.HasColumn("InclusiveKinematicseSigma.x")) {
+    // new style
+    esigma_Q2_col_name = "InclusiveKinematicseSigma.Q2";
+    esigma_x_col_name = "InclusiveKinematicseSigma.x";
+  } else {
+    std::cerr << "Can't find InclusiveKinematicsESigma.Q2 column" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
   auto combinatorial_diff_ratio = [] (
       const ROOT::VecOps::RVec<float>& v1,
       const ROOT::VecOps::RVec<float>& v2
@@ -81,7 +95,7 @@ int dis_electrons(const std::string& config_name)
              .Define("Q2_jb", "InclusiveKinematicsJB.Q2")
              .Define("Q2_da", "InclusiveKinematicsDA.Q2")
              .Define("Q2_sigma", "InclusiveKinematicsSigma.Q2")
-             .Define("Q2_esigma", "InclusiveKinematicsESigma.Q2")
+             .Define("Q2_esigma", esigma_Q2_col_name) // InclusiveKinematicsESigma.Q2
              .Define("logQ2_sim", "log10(Q2_sim)")
              .Define("logQ2_el", "log10(Q2_el)")
              .Define("logQ2_jb", "log10(Q2_jb)")
@@ -98,7 +112,7 @@ int dis_electrons(const std::string& config_name)
              .Define("x_jb", "InclusiveKinematicsJB.x")
              .Define("x_da", "InclusiveKinematicsDA.x")
              .Define("x_sigma", "InclusiveKinematicsSigma.x")
-             .Define("x_esigma", "InclusiveKinematicsESigma.x")
+             .Define("x_esigma", esigma_x_col_name) // InclusiveKinematicsESigma.x
              .Define("x_el_res", combinatorial_diff_ratio, {"x_sim", "x_el"})
              .Define("x_jb_res", combinatorial_diff_ratio, {"x_sim", "x_jb"})
              .Define("x_da_res", combinatorial_diff_ratio, {"x_sim", "x_da"})

--- a/benchmarks/dis/analysis/kinematics_correlations.py
+++ b/benchmarks/dis/analysis/kinematics_correlations.py
@@ -161,8 +161,13 @@ keys = ur.concatenate(rec_file + ':events/' + 'InclusiveKinematicsJB')
 JacquetBlondel =  [keys['InclusiveKinematicsJB.Q2'], keys['InclusiveKinematicsJB.x']]
 keys = ur.concatenate(rec_file + ':events/' + 'InclusiveKinematicsSigma')
 Sigma =  [keys['InclusiveKinematicsSigma.Q2'], keys['InclusiveKinematicsSigma.x']]
-keys = ur.concatenate(rec_file + ':events/' + 'InclusiveKinematicsESigma')
-ESigma =  [keys['InclusiveKinematicsESigma.Q2'], keys['InclusiveKinematicsESigma.x']]
+try:
+    keys = ur.concatenate(rec_file + ':events/' + 'InclusiveKinematicsESigma')
+    ESigma =  [keys['InclusiveKinematicsESigma.Q2'], keys['InclusiveKinematicsESigma.x']]
+except ur.KeyInFileError:
+    # Legacy compatibility
+    keys = ur.concatenate(rec_file + ':events/' + 'InclusiveKinematicseSigma')
+    ESigma =  [keys['InclusiveKinematicseSigma.Q2'], keys['InclusiveKinematicseSigma.x']]
 
 Q2values_T = Truth[0]
 Q2values_E = Electron[0]


### PR DESCRIPTION
This is a follow-up on the #22.

We still want benchmark to be runnable against files generated with previous versions of EICrecon.