### PR TITLE
Backport useful changes from detector_benchmarks

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: mirror
+  group: mirror-${{ github.event_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      statuses: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -29,6 +30,7 @@ jobs:
         username: ${{ secrets.GITLAB_USERNAME }}
         ciskip: true
     - name: Trigger EICweb
+      id: trigger_eicweb
       uses: eic/trigger-gitlab-ci@v3
       if: ${{ github.event_name != 'delete' }}
       with:
@@ -41,3 +43,17 @@ jobs:
           GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_PR=${{ github.event.pull_request.number }}
           PIPELINE_NAME=${{ github.repository }}: ${{ github.event.pull_request.title || github.ref_name }}
+    - name: Set pending EICweb status
+      if: ${{ github.event_name != 'delete' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DETECTOR_CONFIG: epic_craterlake
+      run: |
+        curl \
+          --fail-with-body \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -d '{"context": "eicweb/physics_benchmarks ('"$DETECTOR_CONFIG"')", "state": "pending", "description": "Waiting for response from the EICweb", "target_url": "${{ fromJson(steps.trigger_eicweb.outputs.json).web_url }}"}' \
+          "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,6 @@ variables:
   RECO: "eicrecon"
   DETECTOR: epic
   DETECTOR_CONFIG: epic_craterlake
-  DETECTOR_REPOSITORYURL: 'https://github.com/eic/epic.git'
 
 workflow:
   name: '$PIPELINE_NAME'
@@ -34,7 +33,6 @@ default:
 stages:
   - status-pending
   - config
-  - initialize
   - compile
   - generate
   - simulate
@@ -80,12 +78,6 @@ common:setup:
   script:
     - git clone -b "${COMMON_BENCH_VERSION}" https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git setup 
     - source setup/bin/env.sh && ./setup/bin/install_common.sh
-
-common:detector:
-  stage: initialize
-  needs: ["common:setup"]
-  script:
-    - source .local/bin/env.sh && build_detector.sh
     - mkdir_local_data_link sim_output
     - mkdir_local_data_link datasets
     - mkdir -p results
@@ -100,9 +92,10 @@ common:detector:
 
 .phy_benchmark:
   needs:
-    - ["common:detector"]
+    - ["common:setup"]
   before_script:
     - source .local/bin/env.sh
+    - source /opt/detector/epic-main/setup.sh
     - ls -lrtha 
     - ln -s "${LOCAL_DATA_PATH}/sim_output" sim_output
     - ln -s "${LOCAL_DATA_PATH}/datasets/data" data

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,7 @@ common:setup:
     - ls -lrtha 
     - ln -s "${LOCAL_DATA_PATH}/sim_output" sim_output
     - ln -s "${LOCAL_DATA_PATH}/datasets/data" data
+    - mkdir -p "$SNAKEMAKE_OUTPUT_CACHE"
     - ls -lrtha
   retry:
     max: 2

--- a/Snakefile
+++ b/Snakefile
@@ -22,6 +22,7 @@ root -l -b -q -e '.L {input}+'
 rule fetch_epic:
     output:
         filepath="EPIC/{PATH}"
+    cache: True
     shell: """
 xrdcp root://dtn-eic.jlab.org//work/eic2/{output.filepath} {output.filepath}
 """

--- a/benchmarks/backgrounds/config.yml
+++ b/benchmarks/backgrounds/config.yml
@@ -9,7 +9,7 @@ backgrounds:synchrotron:simulate:
   extends: .phy_benchmark
   tags:
     - s3
-  needs: ["common:detector", "backgrounds:compile"]
+  needs: ["backgrounds:compile"]
   script:
     - bash benchmarks/backgrounds/synchrotron.sh --all
 

--- a/benchmarks/demp/config.yml
+++ b/benchmarks/demp/config.yml
@@ -9,7 +9,7 @@ demp:simulate:
   extends: .phy_benchmark
   timeout: 2 hours
   script:
-    - snakemake --cores 5 demp_run_locally
+    - snakemake --cache --cores 5 demp_run_locally
   retry:
     max: 2
     when:

--- a/benchmarks/diffractive_vm/config.yml
+++ b/benchmarks/diffractive_vm/config.yml
@@ -13,7 +13,7 @@ diffractive_vm:simulate:
       - VM: jpsi
   timeout: 2 hours
   script:
-    - snakemake --cores 10 diffractive_vm_run_locally
+    - snakemake --cache --cores 10 diffractive_vm_run_locally
   retry:
     max: 2
     when:

--- a/benchmarks/dis/config.yml
+++ b/benchmarks/dis/config.yml
@@ -7,7 +7,7 @@ dis:compile:
 dis:simulate:
   stage: simulate
   extends: .phy_benchmark
-  needs: ["common:detector", "dis:compile"]
+  needs: ["dis:compile"]
   parallel:
     matrix:
       - EBEAM: 5

--- a/benchmarks/dis/config.yml
+++ b/benchmarks/dis/config.yml
@@ -22,7 +22,7 @@ dis:simulate:
   timeout: 2 hours
   script:
     - |
-      snakemake --cores 1 \
+      snakemake --cache --cores 1 \
         results/epic_craterlake/dis/${EBEAM}on${PBEAM}/minQ2=${MINQ2}/dis_${EBEAM}x${PBEAM}_minQ2=${MINQ2}dis_electrons.json \
         results/epic_craterlake/dis/${EBEAM}on${PBEAM}/minQ2=${MINQ2}/jets/ \
         results/epic_craterlake/dis/${EBEAM}on${PBEAM}/minQ2=${MINQ2}/kinematics_correlations/ \

--- a/benchmarks/dvcs/config.yml
+++ b/benchmarks/dvcs/config.yml
@@ -9,7 +9,7 @@ dvcs:simulate:
   extends: .phy_benchmark
   tags:
     - phy
-  needs: ["common:detector", "dvcs:compile"]
+  needs: ["dvcs:compile"]
   script:
     #- bash benchmarks/dvcs/dvcs.sh --all
     - bash benchmarks/dvcs/dvcs.sh --data-init --sim --rec

--- a/benchmarks/dvmp/config.yml
+++ b/benchmarks/dvmp/config.yml
@@ -5,7 +5,7 @@ dvmp:compile:
     - compile_analyses.py dvmp
 
 dvmp:generate:
-  needs: ["common:detector", "dvmp:compile"]
+  needs: ["dvmp:compile"]
   image: eicweb.phy.anl.gov:4567/monte_carlo/lager/lager:unstable
   extends: .phy_benchmark
   stage: generate

--- a/benchmarks/tcs/config.yml
+++ b/benchmarks/tcs/config.yml
@@ -9,7 +9,7 @@ tcs:simulate:
   extends: .phy_benchmark
   tags:
     - phy
-  needs: ["common:detector", "tcs:compile"]
+  needs: ["tcs:compile"]
   parallel:
     matrix:
       - EBEAM: 5

--- a/benchmarks/u_omega/config.yml
+++ b/benchmarks/u_omega/config.yml
@@ -9,7 +9,7 @@ u_omega:simulate:
   extends: .phy_benchmark
   tags:
     - phy
-  needs: ["common:detector", "u_omega:compile"]
+  needs: ["u_omega:compile"]
   script:
     #- bash benchmarks/u_omega/u_omega.sh --all
     - bash benchmarks/u_omega/u_omega.sh --data-init --sim --rec


### PR DESCRIPTION
The change https://github.com/eic/epic/pull/713 in how the epic geometry is tested allows to remove some extra logic from benchmarks.

cc https://github.com/eic/detector_benchmarks/pull/69