### PR TITLE
demp: update to DEMPgen-1.2.0 dataset

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/demp/Snakefile
+++ b/benchmarks/Exclusive-Diffraction-Tagging/demp/Snakefile
@@ -38,7 +38,7 @@ ddsim \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
   --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
-  --inputFiles root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/EXCLUSIVE/DEMP/DEMPgen-1.2.0/{wildcards.EBEAM}x{wildcards.PBEAM}/pi+/DEMPgen-1.1.0_{wildcards.EBEAM}x{wildcards.PBEAM}_pi+_{wildcards.INDEX}.hepmc3.tree.root \
+  --inputFiles root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/EXCLUSIVE/DEMP/DEMPgen-1.2.0/{wildcards.EBEAM}x{wildcards.PBEAM}/pi+/DEMPgen-1.2.0_{wildcards.EBEAM}x{wildcards.PBEAM}_pi+_{wildcards.INDEX}.hepmc3.tree.root \
   --outputFile {output}
 """
 

--- a/benchmarks/Exclusive-Diffraction-Tagging/demp/Snakefile
+++ b/benchmarks/Exclusive-Diffraction-Tagging/demp/Snakefile
@@ -9,9 +9,9 @@ rule demp_compile:
 #Process the simulated files based on the user-defined campaign
 rule demp_campaign_reco_get:
     input:
-        lambda wildcards: f"EPIC/RECO/{wildcards.RELEASE_TAG}/{wildcards.DETECTOR_CONFIG}/EXCLUSIVE/DEMP/DEMPgen-1.1.0/{wildcards.EBEAM}x{wildcards.PBEAM}/pi+/DEMPgen-1.1.0_{wildcards.EBEAM}x{wildcards.PBEAM}_pi+_1.000{wildcards.INDEX}.eicrecon.tree.edm4eic.root",
+        lambda wildcards: f"EPIC/RECO/{wildcards.RELEASE_TAG}/{wildcards.DETECTOR_CONFIG}/EXCLUSIVE/DEMP/DEMPgen-1.2.0/{wildcards.EBEAM}x{wildcards.PBEAM}/pi+/DEMPgen-1.2.0_{wildcards.EBEAM}x{wildcards.PBEAM}_pi+_10.000{wildcards.INDEX}.eicrecon.tree.edm4eic.root",
     output:
-        temp("reco/{DETECTOR_CONFIG}/campaign_{RELEASE_TAG}_demp_{EBEAM}on{PBEAM}_{INDEX}.edm4eic.root"),
+        temp("reco/{DETECTOR_CONFIG}/campaign_{RELEASE_TAG}_demp_{EBEAM}x{PBEAM}_{INDEX}.edm4eic.root"),
     shell:
         """
 mv {input} {output}
@@ -22,7 +22,7 @@ rule demp_sim:
     input:
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
     output:
-        "sim/{DETECTOR_CONFIG}/demp_{EBEAM}on{PBEAM}_{INDEX}.edm4hep.root",
+        "sim/{DETECTOR_CONFIG}/demp_{EBEAM}x{PBEAM}_{INDEX}.edm4hep.root",
     params:
         N_EVENTS=100
     wildcard_constraints:
@@ -38,16 +38,16 @@ ddsim \
   -v WARNING \
   --numberOfEvents {params.N_EVENTS} \
   --compactFile $DETECTOR_PATH/{wildcards.DETECTOR_CONFIG}.xml \
-  --inputFiles root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/EXCLUSIVE/DEMP/DEMPgen-1.1.0/{wildcards.EBEAM}x{wildcards.PBEAM}/pi+/DEMPgen-1.1.0_{wildcards.EBEAM}x{wildcards.PBEAM}_pi+_{wildcards.INDEX}.hepmc3.tree.root \
+  --inputFiles root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/EXCLUSIVE/DEMP/DEMPgen-1.2.0/{wildcards.EBEAM}x{wildcards.PBEAM}/pi+/DEMPgen-1.1.0_{wildcards.EBEAM}x{wildcards.PBEAM}_pi+_{wildcards.INDEX}.hepmc3.tree.root \
   --outputFile {output}
 """
 
 #Process the files produced in the previous step through eicrecon
 rule demp_reco:
     input:
-        "sim/{DETECTOR_CONFIG}/demp_{EBEAM}on{PBEAM}_{INDEX}.edm4hep.root",
+        "sim/{DETECTOR_CONFIG}/demp_{EBEAM}x{PBEAM}_{INDEX}.edm4hep.root",
     output:
-        "reco/{DETECTOR_CONFIG}/demp_{EBEAM}on{PBEAM}_{INDEX}.edm4eic.root",
+        "reco/{DETECTOR_CONFIG}/demp_{EBEAM}x{PBEAM}_{INDEX}.edm4eic.root",
     wildcard_constraints:
         EBEAM="\d+",
         PBEAM="\d+",
@@ -62,10 +62,10 @@ rule demp_analysis:
     input:
         script="benchmarks/Exclusive-Diffraction-Tagging/demp/analysis/demp_analysis.cxx",
         script_compiled=ROOT_BUILD_DIR_PREFIX + "benchmarks/Exclusive-Diffraction-Tagging/demp/analysis/demp_analysis_cxx.so",
-        data="reco/{DETECTOR_CONFIG}/{PREFIX}demp_{EBEAM}on{PBEAM}_{INDEX}.edm4eic.root",
+        data="reco/{DETECTOR_CONFIG}/{PREFIX}demp_{EBEAM}x{PBEAM}_{INDEX}.edm4eic.root",
     output:
-        config="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}on{PBEAM}_{INDEX}/config.json",
-        hists="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}on{PBEAM}_{INDEX}/hists.root",
+        config="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_{INDEX}/config.json",
+        hists="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_{INDEX}/hists.root",
     wildcard_constraints:
         PREFIX= ".*",
         EBEAM="\d+",
@@ -88,10 +88,10 @@ root -l -b -q '{input.script}+("{output.config}")'
 #Merge all the files produced in the previous step
 rule demp_combine:
     input:
-        lambda wildcards: [f"results/{wildcards.DETECTOR_CONFIG}/demp/{wildcards.PREFIX}demp_{wildcards.EBEAM}on{wildcards.PBEAM}_{ix}/hists.root" for ix in range(1,int(wildcards.NUM_FILES)+1)],
+        lambda wildcards: [f"results/{wildcards.DETECTOR_CONFIG}/demp/{wildcards.PREFIX}demp_{wildcards.EBEAM}x{wildcards.PBEAM}_{ix}/hists.root" for ix in range(1,int(wildcards.NUM_FILES)+1)],
     output:
-        config="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}on{PBEAM}_combined_{NUM_FILES}/config.json",
-        hists="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}on{PBEAM}_combined_{NUM_FILES}/hists.root",
+        config="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_combined_{NUM_FILES}/config.json",
+        hists="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_combined_{NUM_FILES}/hists.root",
     wildcard_constraints:
         PREFIX= ".*",
         EBEAM="\d+",
@@ -117,9 +117,9 @@ rule demp_plots:
     input:
         script="benchmarks/Exclusive-Diffraction-Tagging/demp/analysis/demp_plots.cxx",
         script_compiled=ROOT_BUILD_DIR_PREFIX + "benchmarks/Exclusive-Diffraction-Tagging/demp/analysis/demp_plots_cxx.so",
-        config="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}on{PBEAM}_combined_{NUM_FILES}/config.json",
+        config="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_combined_{NUM_FILES}/config.json",
     output:
-        "results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}on{PBEAM}_combined_{NUM_FILES}/plots.pdf"
+        "results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_combined_{NUM_FILES}/plots.pdf"
     wildcard_constraints:
         PREFIX= ".*",
         EBEAM="\d+",
@@ -133,13 +133,14 @@ root -l -b -q '{input.script}+("{input.config}")'
 #Example of invocation
 rule demp_run_locally:
     input:
-        "results/" + os.environ["DETECTOR_CONFIG"] + "/demp/demp_5on41_combined_5/plots.pdf",
+        "results/" + os.environ["DETECTOR_CONFIG"] + "/demp/demp_5x41_combined_5/plots.pdf",
     message:
         "See output in {input[0]}"
 
 rule demp_run_campaign:
     input:
-        "results/epic_craterlake/demp/campaign_24.06.0_demp_5on41_combined_5/plots.pdf",
+        "results/epic_craterlake/demp/campaign_24.08.1_demp_5x41_combined_5/plots.pdf",
+        "results/epic_craterlake/demp/campaign_24.09.0_demp_5x41_combined_5/plots.pdf",
     message:
         "See output in {input[0]}"
 


### PR DESCRIPTION
This updates to the new DEMP dataset that is used starting 24.08.1. To keep things simple, the old campaign processing is discontinued.