### PR TITLE
fix: Use raw string when `\d` in wildcard pattern

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/demp/Snakefile
+++ b/benchmarks/Exclusive-Diffraction-Tagging/demp/Snakefile
@@ -26,9 +26,9 @@ rule demp_sim:
     params:
         N_EVENTS=100
     wildcard_constraints:
-        EBEAM="\d+",
-        PBEAM="\d+",
-        INDEX="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        INDEX=r"\d+",
     shell:
         """
 ddsim \
@@ -49,9 +49,9 @@ rule demp_reco:
     output:
         "reco/{DETECTOR_CONFIG}/demp_{EBEAM}x{PBEAM}_{INDEX}.edm4eic.root",
     wildcard_constraints:
-        EBEAM="\d+",
-        PBEAM="\d+",
-        INDEX="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        INDEX=r"\d+",
     shell:
         """
 DETECTOR_CONFIG={wildcards.DETECTOR_CONFIG} eicrecon {input} -Ppodio:output_file={output}
@@ -68,9 +68,9 @@ rule demp_analysis:
         hists="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_{INDEX}/hists.root",
     wildcard_constraints:
         PREFIX= ".*",
-        EBEAM="\d+",
-        PBEAM="\d+",
-        INDEX="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        INDEX=r"\d+",
     shell:
         """
 cat > {output.config} <<EOF
@@ -94,9 +94,9 @@ rule demp_combine:
         hists="results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_combined_{NUM_FILES}/hists.root",
     wildcard_constraints:
         PREFIX= ".*",
-        EBEAM="\d+",
-        PBEAM="\d+",
-        NUM_FILES="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        NUM_FILES=r"\d+",
     shell:
         """
 cat > {output.config} <<EOF
@@ -122,9 +122,9 @@ rule demp_plots:
         "results/{DETECTOR_CONFIG}/demp/{PREFIX}demp_{EBEAM}x{PBEAM}_combined_{NUM_FILES}/plots.pdf"
     wildcard_constraints:
         PREFIX= ".*",
-        EBEAM="\d+",
-        PBEAM="\d+",
-        NUM_FILES="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        NUM_FILES=r"\d+",
     shell:
         """
 root -l -b -q '{input.script}+("{input.config}")'

--- a/benchmarks/Exclusive-Diffraction-Tagging/diffractive_vm/Snakefile
+++ b/benchmarks/Exclusive-Diffraction-Tagging/diffractive_vm/Snakefile
@@ -95,7 +95,7 @@ rule diffractive_vm_combine_sartre:
     wildcard_constraints:
         PREFIX=".*", # can be empty
         PARTICLE="[^_]*",
-        NUM_FILES="\d+",
+        NUM_FILES=r"\d+",
         SUFFIX=".*", # can be empty
     output:
         config="results/{DETECTOR_CONFIG}/diffractive_vm/{PREFIX}sartre_{PARTICLE}_combined_{NUM_FILES}{SUFFIX}/config.json",

--- a/benchmarks/Inclusive/dis/Snakefile
+++ b/benchmarks/Inclusive/dis/Snakefile
@@ -91,9 +91,9 @@ rule dis_analysis_kinematics_correlations:
     params:
         N_EVENTS=100
     wildcard_constraints:
-        EBEAM="\d+",
-        PBEAM="\d+",
-        MINQ2="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        MINQ2=r"\d+",
     shell: """
 mkdir {output.results_path}
 python benchmarks/Inclusive/dis/analysis/kinematics_correlations.py --rec_file "{input.data}" --config dis_{wildcards.EBEAM}x{wildcards.PBEAM}_minQ2={wildcards.MINQ2}_{wildcards.DETECTOR_CONFIG} --results_path {output.results_path} --nevents {params.N_EVENTS}
@@ -108,9 +108,9 @@ rule dis_analysis_truth_reconstruction:
     params:
         N_EVENTS=100
     wildcard_constraints:
-        EBEAM="\d+",
-        PBEAM="\d+",
-        MINQ2="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        MINQ2=r"\d+",
     shell: """
 mkdir {output.results_path}
 python benchmarks/Inclusive/dis/analysis/truth_reconstruction.py --rec_file "{input.data}" --config dis_{wildcards.EBEAM}x{wildcards.PBEAM}_minQ2={wildcards.MINQ2}_{wildcards.DETECTOR_CONFIG} --results_path $(dirname {output.results_path}) --nevents {params.N_EVENTS}

--- a/benchmarks/Jets-HF/jets/Snakefile
+++ b/benchmarks/Jets-HF/jets/Snakefile
@@ -34,9 +34,9 @@ rule jets_analysis_jets:
     output:
         results_path=directory("results/{DETECTOR_CONFIG}/jets/{EBEAM}on{PBEAM}/minQ2={MINQ2}"),
     wildcard_constraints:
-        EBEAM="\d+",
-        PBEAM="\d+",
-        MINQ2="\d+",
+        EBEAM=r"\d+",
+        PBEAM=r"\d+",
+        MINQ2=r"\d+",
     shell: """
 mkdir {output.results_path}
 root -l -b -q '{input.script}+("{input.config}")'


### PR DESCRIPTION
### Briefly, what does this PR introduce?
rrrr.