### PR TITLE
fix: use correct path in Jets-HF/jets jets_compile

### DIFF
--- a/benchmarks/Jets-HF/jets/Snakefile
+++ b/benchmarks/Jets-HF/jets/Snakefile
@@ -1,6 +1,6 @@
 rule jets_compile:
     input:
-        ROOT_BUILD_DIR_PREFIX + "benchmarks/Inclusive/dis/analysis/jets_cxx.so",
+        ROOT_BUILD_DIR_PREFIX + "benchmarks/Jets-HF/jets/analysis/jets_cxx.so",
 
 
 rule jets_generate_config:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes a compile location for Jets-HF/jets jets_compile job.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators @marrbnl @bspage912 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.