### PR TITLE
feat: define default CI_JOB_JWT

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,9 @@ workflow:
   name: '$PIPELINE_NAME'
 
 default:
+  id_tokens:
+    CI_JOB_JWT:
+      aud: ${CI_SERVER_PROTOCOL}://${CI_SERVER_HOST}
   before_script:
     - source .local/bin/env.sh
   tags:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR defines `CI_JOB_JWT` for each job by adding it as a default id_token. This is mainly needed for jacamar authentication, but should not have any impact on regular eicweb running.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: authenticate with `CI_JOB_JWT`)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.