### PR TITLE
tcs: enable debug output for CI failures

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
@@ -106,10 +106,12 @@ echo "DETECTOR    = ${DETECTOR}"
 ## - DETECTOR:       the detector package we want to use for this benchmark
 ## - DETECTOR_PATH:          full path to the detector definitions
 
+set -x
+
 ### Step 1. Run the simulation (geant4)
 if [[ -n "${DO_SIM}" || -n "${DO_ALL}" ]] ; then
   ## run geant4 simulations
-  ddsim --runType batch \
+  command time -v ddsim --runType batch \
     --part.minimalKineticEnergy 1000*GeV  \
     --filter.tracker edep0 \
     -v ERROR \


### PR DESCRIPTION
ddsim appears to silently fail in
https://eicweb.phy.anl.gov/EIC/benchmarks/physics_benchmarks/-/jobs/6205811#L1016 and many similar failures