### PR TITLE
Disambiguate FILE_NAME_TAG

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
@@ -89,7 +89,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 # assuming something like .local/bin/env.sh has already been sourced.
 print_env.sh
 
-FILE_NAME_TAG="tcs"
+FILE_NAME_TAG="tcs_${EBEAM}x${PBEAM}m_${TAG}"
 XROOTD_BASEURL="root://dtn-eic.jlab.org//volatile/eic/EPIC"
 INPUT_FILE="EVGEN/EXCLUSIVE/TCS_ABCONV/${EBEAM}x${PBEAM}/hel_minus/TCS_gen_ab_hiAcc_${EBEAM}x${PBEAM}m_${TAG}.hepmc3.tree.root"
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR disambiguates the `FILE_NAME_TAG` variable to ensure that multiple simulation/reconstruction jobs (outside of snakemake) do not step on each other.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.