### PR TITLE
semi_coherent: specify hepmc3 output format

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/Snakefile
+++ b/benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/Snakefile
@@ -15,18 +15,18 @@ rule semi_coherent_afterburner:
     input:
         "benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered.hepmc",
     output:
-        "benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc.hepmc",
+        "benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc",
     shell:
         """
 abconv {input} \
   --preset 2 \
   --out-format hepmc3 \
-  --output benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc
+  --output benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab
 """
     
 rule semi_coherent_sim:
     input:
-        hepmcfile="benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc.hepmc",
+        hepmcfile="benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc",
         warmup="warmup/{DETECTOR_CONFIG}.edm4hep.root",
         geometry_lib=find_epic_libraries(),
     output:

--- a/benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/Snakefile
+++ b/benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/Snakefile
@@ -18,7 +18,10 @@ rule semi_coherent_afterburner:
         "benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc.hepmc",
     shell:
         """
-abconv {input} -p 2 --output benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc
+abconv {input} \
+  --preset 2 \
+  --out-format hepmc3 \
+  --output benchmarks/Exclusive-Diffraction-Tagging/semi_coherent/filtered_ab.hepmc
 """
     
 rule semi_coherent_sim:


### PR DESCRIPTION
Since https://github.com/eic/afterburner/pull/21 the default format is not hepmc3.

Needed for https://github.com/eic/containers/pull/213