### PR TITLE
chore: remove unused common_bench header includes

### DIFF
--- a/benchmarks/Inclusive/dis/analysis/dis_electrons.cxx
+++ b/benchmarks/Inclusive/dis/analysis/dis_electrons.cxx
@@ -1,6 +1,5 @@
 #include "common_bench/benchmark.h"
 #include "common_bench/mt.h"
-#include "common_bench/util.h"
 #include "common_bench/plot.h"
 
 #include <cmath>

--- a/benchmarks/Jets-HF/jets/analysis/jets.cxx
+++ b/benchmarks/Jets-HF/jets/analysis/jets.cxx
@@ -1,7 +1,3 @@
-#include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
-#include "common_bench/util.h"
-#include "common_bench/plot.h"
 
 #include <TCanvas.h>
 #include <TChain.h>


### PR DESCRIPTION
## Summary

A systematic audit of all analysis scripts in this repo found `common_bench` headers that are included but whose symbols are never referenced.

## Changes

| File | Removed includes |
|------|-----------------|
| `benchmarks/Jets-HF/jets/analysis/jets.cxx` | `benchmark.h`, `mt.h`, `util.h`, `plot.h` (all four — zero `common_bench::` symbols used in the entire 1340-line file) |
| `benchmarks/Inclusive/dis/analysis/dis_electrons.cxx` | `util.h` (`benchmark.h`, `mt.h`, `plot.h` kept; `util.h` was included but none of its functions — `get_pdg_mass`, `momenta_from_simulation`, `find_decay_pair`, etc. — are called) |

## Notes

- `jets.cxx` had vestigial includes carried over from a template or another benchmark script.
- `dis_electrons.cxx` uses `common_bench::plot` colors/labels and `common_bench::Test`/`write_test` heavily — those headers are retained.