### PR TITLE
fix: replace hardcoded kNumThreads with ROOT::EnableImplicitMT()

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_invar.cxx
+++ b/benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_invar.cxx
@@ -2,7 +2,6 @@
 
 #include "common_bench/plot.h"
 #include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
 #include "common_bench/util.h"
 
 #include "ROOT/RDataFrame.hxx"
@@ -56,7 +55,7 @@ int vm_invar(const std::string& config_name)
        {"target", ".1"}}};
 
   // Run this in multi-threaded mode if desired
-  ROOT::EnableImplicitMT(kNumThreads);
+  ROOT::EnableImplicitMT();
 
   // The particles we are looking for. E.g. J/psi decaying into e+e-
   const double vm_mass    = common_bench::get_pdg_mass(vm_name);

--- a/benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_mass.cxx
+++ b/benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_mass.cxx
@@ -2,7 +2,6 @@
 #include "common_bench/plot.h"
 
 #include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
 #include "common_bench/util.h"
 
 #include "ROOT/RDataFrame.hxx"
@@ -73,7 +72,7 @@ int vm_mass(const std::string& config_name)
        {"target", ".2"}}};      //these 2 need to be consistent 
   double width_target = 0.2;    //going to find a way to use the same variable
   // Run this in multi-threaded mode if desired
-  ROOT::EnableImplicitMT(kNumThreads);
+  ROOT::EnableImplicitMT();
 
   // The particles we are looking for. E.g. J/psi decaying into e+e-
   const double vm_mass    = common_bench::get_pdg_mass(vm_name);

--- a/benchmarks/Inclusive/dis/analysis/dis_electrons.cxx
+++ b/benchmarks/Inclusive/dis/analysis/dis_electrons.cxx
@@ -1,5 +1,4 @@
 #include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
 #include "common_bench/util.h"
 #include "common_bench/plot.h"
 
@@ -58,7 +57,7 @@ int dis_electrons(const std::string& config_name)
        {"target", "0.1"}}};
 
   // Run this in multi-threaded mode if desired
-  ROOT::EnableImplicitMT(kNumThreads);
+  ROOT::EnableImplicitMT();
   ROOT::RDataFrame d("events", rec_file);
 
   std::string esigma_Q2_col_name, esigma_x_col_name;


### PR DESCRIPTION
## Summary

`common_bench/mt.h` defines a single compile-time constant `kNumThreads = 8`, which was used in three analysis scripts to limit ROOT's implicit multithreading. This value:

- **Ignores `$BENCHMARK_N_THREADS`** from `env.sh` (CI default: 10)
- **Disagrees with the majority of scripts** — every other analysis in both `detector_benchmarks` and `physics_benchmarks` already calls `ROOT::EnableImplicitMT()` with no argument
- Was flagged with a TODO in the header itself that was never resolved

`ROOT::EnableImplicitMT()` with no argument tells ROOT to use all available hardware threads, which is the correct behavior for CI runners where you want maximum utilization.

## Changes

In three files, replace `ROOT::EnableImplicitMT(kNumThreads)` → `ROOT::EnableImplicitMT()` and remove `#include "common_bench/mt.h"`:

- `benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_mass.cxx`
- `benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_invar.cxx`
- `benchmarks/Inclusive/dis/analysis/dis_electrons.cxx`

## Related

This removes the last users of `common_bench/mt.h`, allowing it to be deleted: eic/common_bench#4