### PR TITLE
refactor: use edm4eic::momenta() in vm_mass.cxx

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_mass.cxx
+++ b/benchmarks/Exclusive-Diffraction-Tagging/dvmp/analysis/vm_mass.cxx
@@ -2,8 +2,9 @@
 #include "common_bench/plot.h"
 
 #include "common_bench/benchmark.h"
-#include "common_bench/mt.h"
 #include "common_bench/util.h"
+
+#include "edm4eic/analysis_utils.h"
 
 #include "ROOT/RDataFrame.hxx"
 #include <cmath>
@@ -18,6 +19,7 @@
 
 #include "edm4eic/ReconstructedParticleCollection.h"
 #include "edm4eic/ReconstructedParticleData.h"
+#include "edm4hep/MCParticleCollection.h"
 
 // Run VM invariant-mass-based benchmarks on an input reconstruction file for
 // a desired vector meson (e.g. jpsi) and a desired decay particle (e.g. muon)
@@ -73,7 +75,7 @@ int vm_mass(const std::string& config_name)
        {"target", ".2"}}};      //these 2 need to be consistent 
   double width_target = 0.2;    //going to find a way to use the same variable
   // Run this in multi-threaded mode if desired
-  ROOT::EnableImplicitMT(kNumThreads);
+  ROOT::EnableImplicitMT();
 
   // The particles we are looking for. E.g. J/psi decaying into e+e-
   const double vm_mass    = common_bench::get_pdg_mass(vm_name);
@@ -96,9 +98,13 @@ int vm_mass(const std::string& config_name)
 
   // common_bench::PrintGeant4(MCParticles);
   // Define analysis flow
-  auto d_im = d.Define("p_rec", common_bench::momenta_RC, {"ReconstructedParticles"})       //using dummy rc
+  auto d_im = d.Define("p_rec",
+                  [](const std::vector<edm4eic::ReconstructedParticleData>& p) { return edm4eic::momenta(p); },
+                  {"ReconstructedParticles"})       //using dummy rc
                   .Define("N", "p_rec.size()")
-                  .Define("p_sim", common_bench::momenta_from_simulation, {"MCParticles"})
+                  .Define("p_sim",
+                  [](const std::vector<edm4hep::MCParticleData>& p) { return edm4eic::momenta(p); },
+                  {"MCParticles"})
                   .Define("decay_pair_rec", find_decay_pair, {"p_rec"})
                   .Define("decay_pair_sim", find_decay_pair, {"p_sim"})
                   .Define("p_vm_rec", "decay_pair_rec.first + decay_pair_rec.second")


### PR DESCRIPTION
## Summary

Replace `common_bench::momenta_RC` and `common_bench::momenta_from_simulation` with the canonical `edm4eic::momenta()` overloads now available in `edm4eic/analysis_utils.h`.

Since `momenta()` is overloaded (for RC and MC particle types), explicit lambdas are used in the RDataFrame `.Define()` calls to select the correct overload.

Also removes the `#include "common_bench/mt.h"` (already removed in #95) and replaces `ROOT::EnableImplicitMT(kNumThreads)` with the no-arg form (consistent with all other benchmark scripts).

**Depends on:** eic/EDM4eic#166 — requires the new `edm4eic::momenta()` overloads to be available in the container.