### PR TITLE
common:setup: clone common_bench directly to .local, drop install_common.sh

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -40,7 +40,7 @@ jobs:
       statuses: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Push to EICweb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,8 +84,8 @@ common:setup:
       echo "COMMON_BENCH_VERSION = ${COMMON_BENCH_VERSION}" 
       echo "COMMON_BENCH_VERSION=${COMMON_BENCH_VERSION}" >> .env
   script:
-    - git clone -b "${COMMON_BENCH_VERSION}" https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git setup 
-    - source setup/bin/env.sh && ./setup/bin/install_common.sh
+    - git clone -b "${COMMON_BENCH_VERSION}" https://eicweb.phy.anl.gov/EIC/benchmarks/common_bench.git .local
+    - source .local/bin/env.sh
     - mkdir_local_data_link sim_output
     - mkdir_local_data_link datasets
     - mkdir -p results

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ common:setup:
       echo "COMMON_BENCH_VERSION = ${COMMON_BENCH_VERSION}" 
       echo "COMMON_BENCH_VERSION=${COMMON_BENCH_VERSION}" >> .env
   script:
-    - git clone -b "${COMMON_BENCH_VERSION}" https://github.com/eic/common_bench.git .local
+    - git clone --depth 1 -b "${COMMON_BENCH_VERSION}" https://github.com/eic/common_bench.git .local
     - rm -rf .local/.git
     - source .local/bin/env.sh
     - mkdir_local_data_link sim_output

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,8 @@ common:setup:
       echo "COMMON_BENCH_VERSION = ${COMMON_BENCH_VERSION}" 
       echo "COMMON_BENCH_VERSION=${COMMON_BENCH_VERSION}" >> .env
   script:
-    - git clone -b "${COMMON_BENCH_VERSION}" https://github.com/eic/common_bench.git .local 
+    - git clone -b "${COMMON_BENCH_VERSION}" https://github.com/eic/common_bench.git .local
+    - rm -rf .local/.git
     - source .local/bin/env.sh
     - mkdir_local_data_link sim_output
     - mkdir_local_data_link datasets


### PR DESCRIPTION
## Summary

`install_common.sh` exists solely to copy `setup/ → .local/`. All downstream jobs already source `.local/bin/env.sh` — `setup/` is never an artifact.

By cloning directly to `.local/`, the separate copy step is eliminated and `install_common.sh` becomes dead code.

### Change

```diff
- git clone -b "${COMMON_BENCH_VERSION}" .../common_bench.git setup
- source setup/bin/env.sh && ./setup/bin/install_common.sh
+ git clone -b "${COMMON_BENCH_VERSION}" .../common_bench.git .local
+ source .local/bin/env.sh
```

No downstream jobs are affected — they all already source `.local/bin/env.sh`.