### PR TITLE
fix: rm parse_cmd.sh and centralize EDT shared options

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/dvcs/dvcs.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/dvcs/dvcs.sh
@@ -1,72 +1,15 @@
 #!/bin/bash
 source strict-mode.sh
 
+source benchmarks/Exclusive-Diffraction-Tagging/options.sh
+
 function print_the_help {
-  echo "USAGE: ${0} [--rec] [--sim] [--analysis] [--all] "
-  echo "    The default options are to run all steps (sim,rec,analysis) "
-  echo "OPTIONS: "
-  echo "  --data-init     download the input event data"
-  echo "  --sim,-s        Runs the Geant4 simulation"
-  echo "  --rec,-r        Run the reconstruction"
-  echo "  --analysis,-a   Run the analysis scripts"
-  echo "  --all           (default) Do all steps. Argument is included so usage can convey intent."
-  exit 
+  echo "USAGE: ${0} [--sim] [--rec] [--analysis] [--all]"
+  print_step_options_help
+  exit
 }
 
-DO_ALL=1
-DATA_INIT=
-DO_SIM=
-DO_REC=
-DO_ANALYSIS=
-
-POSITIONAL=()
-while [[ $# -gt 0 ]]
-do
-  key="$1"
-
-  case $key in
-    -h|--help)
-      shift # past argument
-      print_the_help
-      ;;
-    --all)
-      DO_ALL=2
-      if [[ ! "${DO_REC}${DO_SIM}${DO_ANALYSIS}" -eq "" ]] ; then
-        echo "Error: cannot use --all with other arguments." 1>&2
-        print_the_help
-        exit 1
-      fi
-      shift # past value
-      ;;
-    -s|--sim)
-      DO_SIM=1
-      DO_ALL=
-      shift # past value
-      ;;
-    --data-init)
-      DATA_INIT=1
-      DO_ALL=
-      shift # past value
-      ;;
-    -r|--rec)
-      DO_REC=1
-      DO_ALL=
-      shift # past value
-      ;;
-    -a|--analysis)
-      DO_ANALYSIS=1
-      DO_ALL=
-      shift # past value
-      ;;
-    *)    # unknown option
-      #POSITIONAL+=("$1") # save it in an array for later
-      echo "unknown option $1"
-      print_the_help
-      shift # past argument
-      ;;
-  esac
-done
-set -- "${POSITIONAL[@]}" # restore positional parameters
+parse_step_options "$@"
 
 # assuming something like .local/bin/env.sh has already been sourced.
 print_env.sh

--- a/benchmarks/Exclusive-Diffraction-Tagging/dvmp/dvmp.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/dvmp/dvmp.sh
@@ -20,16 +20,83 @@ echo "Running the DVMP benchmarks"
 ## =============================================================================
 ## Step 1: Setup the environment variables
 ##
-## First parse the command line flags.
+## Parse the command line flags.
 ## This sets the following environment variables:
 ## - CONFIG:   The specific generator configuration
 ## - EBEAM:    The electron beam energy
 ## - PBEAM:    The ion beam energy
 ## - DECAY:    The decay particle for the generator
 ## - LEADING:  Leading particle of interest (J/psi)
-export REQUIRE_DECAY=1
-export REQUIRE_LEADING=1
-source parse_cmd.sh $@
+
+function print_the_help {
+  echo "USAGE: ${0} --config C --ebeam E --pbeam P --decay D --leading L"
+  echo "REQUIRED OPTIONS:"
+  echo "  --config C    Generator configuration identifier"
+  echo "  --ebeam E     Electron beam energy"
+  echo "  --pbeam P     Ion beam energy"
+  echo "  --decay D     Decay particle (e.g. muon, electron)"
+  echo "  --leading L   Leading particle of interest (e.g. jpsi)"
+  echo "  -h,--help     Print this message"
+  exit
+}
+
+CONFIG=
+EBEAM=
+PBEAM=
+DECAY=
+LEADING=
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --config)
+      CONFIG="$2"
+      shift; shift
+      ;;
+    --ebeam)
+      EBEAM="$2"
+      shift; shift
+      ;;
+    --pbeam)
+      PBEAM="$2"
+      shift; shift
+      ;;
+    --decay)
+      DECAY="$2"
+      shift; shift
+      ;;
+    --leading)
+      LEADING="$2"
+      shift; shift
+      ;;
+    -h|--help)
+      print_the_help
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'"
+      print_the_help
+      ;;
+  esac
+done
+
+if [[ -z "${CONFIG}" ]]; then
+  echo "ERROR: --config is required"
+  print_the_help
+elif [[ -z "${EBEAM}" ]]; then
+  echo "ERROR: --ebeam is required"
+  print_the_help
+elif [[ -z "${PBEAM}" ]]; then
+  echo "ERROR: --pbeam is required"
+  print_the_help
+elif [[ -z "${DECAY}" ]]; then
+  echo "ERROR: --decay is required"
+  print_the_help
+elif [[ -z "${LEADING}" ]]; then
+  echo "ERROR: --leading is required"
+  print_the_help
+fi
+
+export CONFIG EBEAM PBEAM DECAY LEADING
 
 ## We also need the following benchmark-specific variables:
 ##

--- a/benchmarks/Exclusive-Diffraction-Tagging/dvmp/gen.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/dvmp/gen.sh
@@ -19,14 +19,73 @@ pushd ${PROJECT_ROOT}
 ## =============================================================================
 ## Step 1: Setup the environment variables
 ##
-## First parse the command line flags.
+## Parse the command line flags.
 ## This sets the following environment variables:
 ## - CONFIG:   The specific generator configuration
 ## - EBEAM:    The electron beam energy
 ## - PBEAM:    The ion beam energy
 ## - DECAY:    The decay particle for the generator
-export REQUIRE_DECAY=1
-source parse_cmd.sh $@
+
+function print_the_help {
+  echo "USAGE: ${0} --config C --ebeam E --pbeam P --decay D"
+  echo "REQUIRED OPTIONS:"
+  echo "  --config C    Generator configuration identifier"
+  echo "  --ebeam E     Electron beam energy"
+  echo "  --pbeam P     Ion beam energy"
+  echo "  --decay D     Decay particle (e.g. muon, electron)"
+  echo "  -h,--help     Print this message"
+  exit
+}
+
+CONFIG=
+EBEAM=
+PBEAM=
+DECAY=
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --config)
+      CONFIG="$2"
+      shift; shift
+      ;;
+    --ebeam)
+      EBEAM="$2"
+      shift; shift
+      ;;
+    --pbeam)
+      PBEAM="$2"
+      shift; shift
+      ;;
+    --decay)
+      DECAY="$2"
+      shift; shift
+      ;;
+    -h|--help)
+      print_the_help
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'"
+      print_the_help
+      ;;
+  esac
+done
+
+if [[ -z "${CONFIG}" ]]; then
+  echo "ERROR: --config is required"
+  print_the_help
+elif [[ -z "${EBEAM}" ]]; then
+  echo "ERROR: --ebeam is required"
+  print_the_help
+elif [[ -z "${PBEAM}" ]]; then
+  echo "ERROR: --pbeam is required"
+  print_the_help
+elif [[ -z "${DECAY}" ]]; then
+  echo "ERROR: --decay is required"
+  print_the_help
+fi
+
+export CONFIG EBEAM PBEAM DECAY
 
 ## To run the generator, we need the following global variables:
 ##

--- a/benchmarks/Exclusive-Diffraction-Tagging/options.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/options.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+## =============================================================================
+## Shared step-control functions for Exclusive-Diffraction-Tagging benchmarks.
+##
+## Source this file (do not run it directly). It defines:
+##
+##   print_step_options_help  - prints the step-option help text; call this from
+##                              the sourcing script's print_the_help function
+##   parse_step_options "$@"  - parses step-control flags and sets:
+##                                DO_ALL, DATA_INIT, DO_SIM, DO_REC, DO_ANALYSIS
+##                              Calls print_the_help (must be defined by caller)
+##                              on -h/--help or unknown options.
+##
+## Usage in a benchmark script:
+##
+##   source benchmarks/Exclusive-Diffraction-Tagging/options.sh
+##
+##   function print_the_help {
+##     echo "USAGE: ${0} [--sim] [--rec] [--analysis] [--all]"
+##     print_step_options_help
+##     exit
+##   }
+##
+##   parse_step_options "$@"
+##
+## =============================================================================
+
+function print_step_options_help {
+  echo "    The default behavior is to run all steps (sim, rec, analysis)."
+  echo "STEP OPTIONS:"
+  echo "  --data-init     Download the input event data"
+  echo "  --sim, -s       Run the Geant4 simulation"
+  echo "  --rec, -r       Run the reconstruction"
+  echo "  --analysis, -a  Run the analysis scripts"
+  echo "  --all           (default) Run all steps"
+  echo "  -h, --help      Print this message"
+}
+
+function parse_step_options {
+  DO_ALL=1
+  DATA_INIT=
+  DO_SIM=
+  DO_REC=
+  DO_ANALYSIS=
+
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+      -h|--help)
+        print_the_help
+        ;;
+      --all)
+        DO_ALL=1
+        if [[ -n "${DO_REC}${DO_SIM}${DO_ANALYSIS}" ]]; then
+          echo "Error: cannot use --all with other step arguments." 1>&2
+          print_the_help
+          exit 1
+        fi
+        shift
+        ;;
+      -s|--sim)
+        DO_SIM=1
+        DO_ALL=
+        shift
+        ;;
+      --data-init)
+        DATA_INIT=1
+        DO_ALL=
+        shift
+        ;;
+      -r|--rec)
+        DO_REC=1
+        DO_ALL=
+        shift
+        ;;
+      -a|--analysis)
+        DO_ANALYSIS=1
+        DO_ALL=
+        shift
+        ;;
+      *)
+        echo "unknown option '$1'" 1>&2
+        print_the_help
+        exit 1
+        ;;
+    esac
+  done
+}

--- a/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 source strict-mode.sh
+source benchmarks/Exclusive-Diffraction-Tagging/options.sh
 
 function print_the_help {
-  echo "USAGE: ${0} [--rec] [--sim] [--analysis] [--all] "
-  echo "    The default options are to run all steps (sim,rec,analysis) "
-  echo "OPTIONS: "
-  echo "  --data-init     download the input event data"
-  echo "  --sim,-s        Runs the Geant4 simulation"
-  echo "  --rec,-r        Run the reconstruction"
-  echo "  --analysis,-a   Run the analysis scripts"
-  echo "  --all           (default) Do all steps. Argument is included so usage can convey intent."
-  exit 
+  echo "USAGE: ${0} --ebeam E --pbeam P --tag T [--sim] [--rec] [--analysis] [--all]"
+  echo "SCRIPT OPTIONS:"
+  echo "  --ebeam E       Electron beam energy"
+  echo "  --pbeam P       Ion beam energy"
+  echo "  --tag T         Event file tag"
+  print_step_options_help
+  exit
 }
 
 DO_ALL=1
@@ -22,69 +21,60 @@ EBEAM=
 PBEAM=
 TAG=
 
-POSITIONAL=()
-while [[ $# -gt 0 ]]
-do
+while [[ $# -gt 0 ]]; do
   key="$1"
-
   case $key in
     -h|--help)
-      shift # past argument
       print_the_help
       ;;
     --all)
-      DO_ALL=2
-      if [[ ! "${DO_REC}${DO_SIM}${DO_ANALYSIS}" -eq "" ]] ; then
-        echo "Error: cannot use --all with other arguments." 1>&2
+      DO_ALL=1
+      if [[ -n "${DO_REC}${DO_SIM}${DO_ANALYSIS}" ]]; then
+        echo "Error: cannot use --all with other step arguments." 1>&2
         print_the_help
         exit 1
       fi
-      shift # past value
+      shift
       ;;
     --tag)
-      shift # past argument
-      TAG=$1
-      shift # past value
+      TAG="$2"
+      shift; shift
       ;;
     --pbeam)
-      shift # past argument
-      PBEAM=$1
-      shift # past value
+      PBEAM="$2"
+      shift; shift
       ;;
     --ebeam)
-      shift # past argument
-      EBEAM=$1
-      shift # past value
+      EBEAM="$2"
+      shift; shift
       ;;
     -s|--sim)
       DO_SIM=1
       DO_ALL=
-      shift # past value
+      shift
       ;;
     --data-init)
       DATA_INIT=1
       DO_ALL=
-      shift # past value
+      shift
       ;;
     -r|--rec)
       DO_REC=1
       DO_ALL=
-      shift # past value
+      shift
       ;;
     -a|--analysis)
       DO_ANALYSIS=1
       DO_ALL=
-      shift # past value
+      shift
       ;;
-    *)    # unknown option
-      #POSITIONAL+=("$1") # save it in an array for later
-      echo "unknown option $1"
+    *)
+      echo "unknown option '$1'" 1>&2
       print_the_help
-      shift # past argument
+      exit 1
       ;;
   esac
 done
-set -- "${POSITIONAL[@]}" # restore positional parameters
 
 # assuming something like .local/bin/env.sh has already been sourced.
 print_env.sh

--- a/benchmarks/Exclusive-Diffraction-Tagging/u_omega/u_omega.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/u_omega/u_omega.sh
@@ -1,72 +1,15 @@
 #!/bin/bash
 source strict-mode.sh
 
+source benchmarks/Exclusive-Diffraction-Tagging/options.sh
+
 function print_the_help {
-  echo "USAGE: ${0} [--rec] [--sim] [--analysis] [--all] "
-  echo "    The default options are to run all steps (sim,rec,analysis) "
-  echo "OPTIONS: "
-  echo "  --data-init     download the input event data"
-  echo "  --sim,-s        Runs the Geant4 simulation"
-  echo "  --rec,-r        Run the reconstruction"
-  echo "  --analysis,-a   Run the analysis scripts"
-  echo "  --all           (default) Do all steps. Argument is included so usage can convey intent."
-  exit 
+  echo "USAGE: ${0} [--sim] [--rec] [--analysis] [--all]"
+  print_step_options_help
+  exit
 }
 
-DO_ALL=1
-DATA_INIT=
-DO_SIM=
-DO_REC=
-DO_ANALYSIS=
-
-POSITIONAL=()
-while [[ $# -gt 0 ]]
-do
-  key="$1"
-
-  case $key in
-    -h|--help)
-      shift # past argument
-      print_the_help
-      ;;
-    --all)
-      DO_ALL=2
-      if [[ ! "${DO_REC}${DO_SIM}${DO_ANALYSIS}" -eq "" ]] ; then
-        echo "Error: cannot use --all with other arguments." 1>&2
-        print_the_help
-        exit 1
-      fi
-      shift # past value
-      ;;
-    -s|--sim)
-      DO_SIM=1
-      DO_ALL=
-      shift # past value
-      ;;
-    --data-init)
-      DATA_INIT=1
-      DO_ALL=
-      shift # past value
-      ;;
-    -r|--rec)
-      DO_REC=1
-      DO_ALL=
-      shift # past value
-      ;;
-    -a|--analysis)
-      DO_ANALYSIS=1
-      DO_ALL=
-      shift # past value
-      ;;
-    *)    # unknown option
-      #POSITIONAL+=("$1") # save it in an array for later
-      echo "unknown option $1"
-      print_the_help
-      shift # past argument
-      ;;
-  esac
-done
-set -- "${POSITIONAL[@]}" # restore positional parameters
+parse_step_options "$@"
 
 # assuming something like .local/bin/env.sh has already been sourced.
 print_env.sh


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
This PR removes the legacy `parse_cmd.sh` use and centralizes some of the shared options by the exlcusive/diffractive/tagging benchmarks (script-based) to avoid duplication. At some point someone in the exlcusive/diffractive/tagging WG can migrate those properly to snakemake.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue: rm cruft)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.

Human identified what needed to be done, directed GitHub Copilot (Clause Sonnet 4.6) to move the content around as indicated, human reviewed and tested (in particular that bash does lazy function evaluation).