### PR TITLE
fix: remove print_env.sh calls from tcs, dvcs, u_omega

### DIFF
--- a/benchmarks/Exclusive-Diffraction-Tagging/dvcs/dvcs.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/dvcs/dvcs.sh
@@ -12,7 +12,6 @@ function print_the_help {
 parse_step_options "$@"
 
 # assuming something like .local/bin/env.sh has already been sourced.
-print_env.sh
 
 FILE_NAME_TAG="dvcs"
 XROOTD_BASEURL="root://dtn-eic.jlab.org//volatile/eic/EPIC"

--- a/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh
@@ -77,7 +77,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 # assuming something like .local/bin/env.sh has already been sourced.
-print_env.sh
 
 FILE_NAME_TAG="tcs_${EBEAM}x${PBEAM}m_${TAG}"
 XROOTD_BASEURL="root://dtn-eic.jlab.org//volatile/eic/EPIC"

--- a/benchmarks/Exclusive-Diffraction-Tagging/u_omega/u_omega.sh
+++ b/benchmarks/Exclusive-Diffraction-Tagging/u_omega/u_omega.sh
@@ -12,7 +12,6 @@ function print_the_help {
 parse_step_options "$@"
 
 # assuming something like .local/bin/env.sh has already been sourced.
-print_env.sh
 
 FILE_NAME_TAG="u_omega"
 XROOTD_BASEURL="root://dtn-eic.jlab.org//volatile/eic/EPIC"


### PR DESCRIPTION
## Summary

Removes the remaining `print_env.sh` calls in three benchmark scripts that were missed in the earlier sweep (PR #102).

`print_env.sh` prints several variables (`BEAMLINE_*`, `DETECTOR_PREFIX`, `JUGGLER_TAG`) that were removed from `env.sh` in common_bench and are no longer set in the CI environment, producing empty/misleading output.

## Files changed
- `benchmarks/Exclusive-Diffraction-Tagging/tcs/tcs.sh`
- `benchmarks/Exclusive-Diffraction-Tagging/dvcs/dvcs.sh`
- `benchmarks/Exclusive-Diffraction-Tagging/u_omega/u_omega.sh`

After this and eic/detector_benchmarks#290 merge, `print_env.sh` itself can be removed from common_bench.