### PR TITLE
Fix Mistakes from EDM Switchover

### DIFF
--- a/benchmarks/Jets-HF/jets/analysis/jets.cxx
+++ b/benchmarks/Jets-HF/jets/analysis/jets.cxx
@@ -5,6 +5,7 @@
 #include <TGraph.h>
 #include <TH1D.h>
 #include <TH2D.h>
+#include <TTree.h>
 #include <TTreeReader.h>
 #include <TTreeReaderArray.h>
 #include <TLegend.h>
@@ -19,6 +20,14 @@
 // Author: B. Page (bpage@bnl.gov)
 
 // To run: snakemake -c1 results/epic_craterlake/jets/10on100/minQ2=1
+
+bool branchExists(TTree* tree, const std::string& branch) {
+  bool exists = false;
+  if(tree->GetBranch(branch.c_str())) {
+    exists = true;
+  }
+  return exists;
+}
 
 int jets(const std::string& config_name)
 {
@@ -66,28 +75,59 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
   // Set Delta R Cut
   float DELTARCUT = 0.05;
 
+  // Check if area branch exists
+  //   --> Using jet EDM if it does!
+  bool useNewEDM = false;
+#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
+  {
+    auto file = TFile::Open(rec_file.c_str(), "READ");
+    auto tree = file->Get<TTree>("events");
+    bool hasRecoArea = branchExists(tree, "ReconstructedChargedJets.area");
+    bool hasGenArea = branchExists(tree, "GeneratedChargedJets.area");
+    useNewEDM = hasRecoArea && hasGenArea;
+  }
+#endif
+
+  // Set area branches to dummy values if not using jet EDM
+  //   --> These branches won't be used if not using
+  //       jet EDM
+  std::string recoAreaBranch = "ReconstructedChargedJets.energy";
+  std::string genAreaBranch = "GeneratedChargedJets.energy";
+  if(useNewEDM) {
+    recoAreaBranch = "ReconstructedChargedJets.area";
+    genAreaBranch = "GeneratedChargedJets.area";
+  }
+
+  // Use updated constituent branch names if using jet EDM
+  std::string recoCstsBeginBranch = "ReconstructedChargedJets.particles_begin";
+  std::string recoCstsEndBranch = "ReconstructedChargedJets.particles_end";
+  std::string recoCstIndexBranch = "_ReconstructedChargedJets_particles.index";
+  if (useNewEDM) {
+    recoCstsBeginBranch = "ReconstructedChargedJets.constituents_begin";
+    recoCstsEndBranch = "ReconstructedChargedJets.constituents_end";
+    recoCstIndexBranch = "_ReconstructedChargedJets_constituents.index";
+  }
+
+  std::string genCstsBeginBranch = "GeneratedChargedJets.particles_begin";
+  std::string genCstsEndBranch = "GeneratedChargedJets.particles_end";
+  std::string genCstIndexBranch = "_GeneratedChargedJets_particles.index";
+  if (useNewEDM) {
+    genCstsBeginBranch = "GeneratedChargedJets.constituents_begin";
+    genCstsEndBranch = "GeneratedChargedJets.constituents_end";
+    genCstIndexBranch = "_GeneratedChargedJets_constituents.index";
+  }
+
   // Reco Jets
   TTreeReaderArray<int> recoType = {tree_reader, "ReconstructedChargedJets.type"};
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TTreeReaderArray<float> recoArea = {tree_reader, "ReconstructedChargedJets.area"};
-#endif
   TTreeReaderArray<float> recoNRG = {tree_reader, "ReconstructedChargedJets.energy"};
   TTreeReaderArray<float> recoMomX = {tree_reader, "ReconstructedChargedJets.momentum.x"};
   TTreeReaderArray<float> recoMomY = {tree_reader, "ReconstructedChargedJets.momentum.y"};
   TTreeReaderArray<float> recoMomZ = {tree_reader, "ReconstructedChargedJets.momentum.z"};
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TTreeReaderArray<unsigned int> recoCstsBegin = {tree_reader, "ReconstructedChargedJets.constituents_begin"};
-  TTreeReaderArray<unsigned int> recoCstsEnd = {tree_reader, "ReconstructedChargedJets.constituents_end"};
-#else
-  TTreeReaderArray<unsigned int> recoCstsBegin = {tree_reader, "ReconstructedChargedJets.particles_begin"};
-  TTreeReaderArray<unsigned int> recoCstsEnd = {tree_reader, "ReconstructedChargedJets.particles_end"};
-#endif
+  TTreeReaderArray<float> recoArea = {tree_reader, recoAreaBranch.c_str()};
+  TTreeReaderArray<unsigned int> recoCstsBegin = {tree_reader, recoCstsBeginBranch.c_str()};
+  TTreeReaderArray<unsigned int> recoCstsEnd = {tree_reader, recoCstsEndBranch.c_str()};
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TTreeReaderArray<int> recoCstIndex = {tree_reader, "_ReconstructedChargedJets_constituents.index"};
-#else
-  TTreeReaderArray<int> recoCstIndex = {tree_reader, "_ReconstructedChargedJets_particles.index"};
-#endif
+  TTreeReaderArray<int> recoCstIndex = {tree_reader, recoCstIndexBranch.c_str()};
 
   // Reconstructed Particles
   TTreeReaderArray<float> recoPartMomX = {tree_reader, "ReconstructedChargedParticles.momentum.x"};
@@ -97,32 +137,21 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
   TTreeReaderArray<int> recoPartPDG = {tree_reader, "ReconstructedChargedParticles.PDG"};
   TTreeReaderArray<float> recoPartNRG = {tree_reader, "ReconstructedChargedParticles.energy"};
 
-  TTreeReaderArray<unsigned int> recoPartAssocRec = {tree_reader, "ReconstructedChargedParticleAssociations.recID"}; // Reco <-> MCParticle
-  TTreeReaderArray<unsigned int> recoPartAssocSim = {tree_reader, "ReconstructedChargedParticleAssociations.simID"};
+  TTreeReaderArray<int> recoPartAssocRec = {tree_reader, "_ReconstructedChargedParticleAssociations_rec.index"}; // Reco <-> MCParticle
+  TTreeReaderArray<int> recoPartAssocSim = {tree_reader, "_ReconstructedChargedParticleAssociations_sim.index"};
   TTreeReaderArray<float> recoPartAssocWeight = {tree_reader, "ReconstructedChargedParticleAssociations.weight"};
 
   // Generated Jets
   TTreeReaderArray<int> genType = {tree_reader, "GeneratedChargedJets.type"};
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TTreeReaderArray<float> genArea = {tree_reader, "GeneratedChargedJets.area"};
-#endif
   TTreeReaderArray<float> genNRG = {tree_reader, "GeneratedChargedJets.energy"};
   TTreeReaderArray<float> genMomX = {tree_reader, "GeneratedChargedJets.momentum.x"};
   TTreeReaderArray<float> genMomY = {tree_reader, "GeneratedChargedJets.momentum.y"};
   TTreeReaderArray<float> genMomZ = {tree_reader, "GeneratedChargedJets.momentum.z"};
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TTreeReaderArray<unsigned int> genCstsBegin = {tree_reader, "GeneratedChargedJets.constituents_begin"};
-  TTreeReaderArray<unsigned int> genCstsEnd = {tree_reader, "GeneratedChargedJets.constituents_end"};
-#else
-  TTreeReaderArray<unsigned int> genCstsBegin = {tree_reader, "GeneratedChargedJets.particles_begin"};
-  TTreeReaderArray<unsigned int> genCstsEnd = {tree_reader, "GeneratedChargedJets.particles_end"};
-#endif
+  TTreeReaderArray<float> genArea = {tree_reader, genAreaBranch.c_str()};
+  TTreeReaderArray<unsigned int> genCstsBegin = {tree_reader, genCstsBeginBranch.c_str()};
+  TTreeReaderArray<unsigned int> genCstsEnd = {tree_reader, genCstsEndBranch.c_str()};
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TTreeReaderArray<int> genPartIndex = {tree_reader, "_GeneratedChargedJets_constituents.index"};
-#else
-  TTreeReaderArray<int> genPartIndex = {tree_reader, "_GeneratedChargedJets_particles.index"};
-#endif
+  TTreeReaderArray<int> genPartIndex = {tree_reader, genCstIndexBranch.c_str()};
   //TTreeReaderArray<int> genChargedIndex = {tree_reader, "GeneratedChargedParticles_objIdx.index"};
   
   // MC
@@ -148,20 +177,24 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
   TH1D *numRecoChargedJetsECutHist = new TH1D("numRecoChargedJetsECut","",20,0.,20.);
   TH1D *recoChargedJetEHist = new TH1D("recoChargedJetE","",300,0.,300.);
   TH1D *recoChargedJetEtaECutHist = new TH1D("recoChargedJetEtaECut","",60,-3.,3.);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TH1D *recoChargedJetAreaECutHist = new TH1D("recoChargedJetAreaECut",250,0.,5.);
-  TH2D *recoChargedJetEvsAreaHist = new TH2D("recoChargedJetEvsArea",""250,0.,5.,300,0.,300.);
-#endif
+  TH1D *recoChargedJetAreaECutHist = nullptr;
+  TH2D *recoChargedJetEvsAreaHist = nullptr;
+  if (useNewEDM) {
+    recoChargedJetAreaECutHist = new TH1D("recoChargedJetAreaECut","",250,0.,5.);
+    recoChargedJetEvsAreaHist = new TH2D("recoChargedJetEvsArea","",250,0.,5.,300,0.,300.);
+  }
   TH2D *recoChargedJetEvsEtaHist = new TH2D("recoChargedJetEvsEta","",60,-3.,3.,300,0.,300.);
   TH2D *recoChargedJetPhiVsEtaECutHist = new TH2D("recoChargedJetPhiVsEtaECut","",60,-3.,3.,100,-TMath::Pi(),TMath::Pi());
 
   TH1D *numRecoChargedJetsECutNoElecHist = new TH1D("numRecoChargedJetsECutNoElec","",20,0.,20.);
   TH1D *recoChargedJetENoElecHist = new TH1D("recoChargedJetENoElec","",300,0.,300.);
   TH1D *recoChargedJetEtaECutNoElecHist = new TH1D("recoChargedJetEtaECutNoElec","",60,-3.,3.);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TH1D *recoChargedJetAreaECutNoElecHist = new TH1D("recoHargedJetAreaECutNoElec","",250,0.,5.);
-  TH2D *recoChargedJetEvsAreaNoElecHist = new TH2D("recoChargedJetEvsAreaNoElec",250,0.,5.,300,0.,300.);
-#endif
+  TH1D *recoChargedJetAreaECutNoElecHist = nullptr;
+  TH2D *recoChargedJetEvsAreaNoElecHist = nullptr;
+  if (useNewEDM) {
+    recoChargedJetAreaECutNoElecHist = new TH1D("recoHargedJetAreaECutNoElec","",250,0.,5.);
+    recoChargedJetEvsAreaNoElecHist = new TH2D("recoChargedJetEvsAreaNoElec","",250,0.,5.,300,0.,300.);
+  }
   TH2D *recoChargedJetEvsEtaNoElecHist = new TH2D("recoChargedJetEvsEtaNoElec","",60,-3.,3.,300,0.,300.);
   TH2D *recoChargedJetPhiVsEtaECutNoElecHist = new TH2D("recoChargedJetPhiVsEtaECutNoElec","",60,-3.,3.,100,-TMath::Pi(),TMath::Pi());
 
@@ -183,20 +216,24 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
   TH1D *numGenChargedJetsECutHist = new TH1D("numGenChargedJetsECut","",20,0.,20.);
   TH1D *genChargedJetEHist = new TH1D("genChargedJetE","",300,0.,300.);
   TH1D *genChargedJetEtaECutHist = new TH1D("genChargedJetEtaECut","",60,-3.,3.);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TH1D *genChargedJetAreaECutHist = new TH1D("genChargedJetAreaECut","",250,0.,5.);
-  TH2D *genChargedJetEvsAreaHist = new TH2D("genChargedJetEvsAreaHist",250,0.,5.,300,0.,300.);
-#endif
+  TH1D *genChargedJetAreaECutHist = nullptr;
+  TH2D *genChargedJetEvsAreaHist = nullptr;
+  if (useNewEDM) {
+    genChargedJetAreaECutHist = new TH1D("genChargedJetAreaECut","",250,0.,5.);
+    genChargedJetEvsAreaHist = new TH2D("genChargedJetEvsAreaHist","",250,0.,5.,300,0.,300.);
+  }
   TH2D *genChargedJetEvsEtaHist = new TH2D("genChargedJetEvsEta","",60,-3.,3.,300,0.,300.);
   TH2D *genChargedJetPhiVsEtaECutHist = new TH2D("genChargedJetPhiVsEtaECut","",60,-3.,3.,100,-TMath::Pi(),TMath::Pi());
 
   TH1D *numGenChargedJetsECutNoElecHist = new TH1D("numGenChargedJetsECutNoElec","",20,0.,20.);
   TH1D *genChargedJetENoElecHist = new TH1D("genChargedJetENoElec","",300,0.,300.);
   TH1D *genChargedJetEtaECutNoElecHist = new TH1D("genChargedJetEtaECutNoElec","",60,-3.,3.);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TH1D *genChargedJetAreaECutNoElecHist = new TH1D("genChargedJetAreaECutNoElec","",250,0.,5.);
-  TH2D *genChargedJetEvsAreaNoElecHist = new TH2D("genChargedJetEvsAreaNoElec","",250,0.,5.,300,0.,300.);
-#endif
+  TH1D *genChargedJetAreaECutNoElecHist = nullptr;
+  TH2D *genChargedJetEvsAreaNoElecHist = nullptr;
+  if (useNewEDM) {
+    genChargedJetAreaECutNoElecHist = new TH1D("genChargedJetAreaECutNoElec","",250,0.,5.);
+    genChargedJetEvsAreaNoElecHist = new TH2D("genChargedJetEvsAreaNoElec","",250,0.,5.,300,0.,300.);
+  }
   TH2D *genChargedJetEvsEtaNoElecHist = new TH2D("genChargedJetEvsEtaNoElec","",60,-3.,3.,300,0.,300.);
   TH2D *genChargedJetPhiVsEtaECutNoElecHist = new TH2D("genChargedJetPhiVsEtaECutNoElec","",60,-3.,3.,100,-TMath::Pi(),TMath::Pi());
 
@@ -219,9 +256,10 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
   TH1D *matchJetDeltaRBackHist = new TH1D("matchJetDeltaRBack","",5000,0.,5.);
   TH2D *recoVsGenChargedJetEtaHist = new TH2D("recoVsGenChargedJetEta","",80,-4.,4.,80,-4.,4.);
   TH2D *recoVsGenChargedJetPhiHist = new TH2D("recoVsGenChargedJetPhi","",100,-TMath::Pi(),TMath::Pi(),100,-TMath::Pi(),TMath::Pi());
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-  TH2D *recoVsGenChargedJetAreaHist = new TH2D("recoVsGenChargedJetArea","",250,0.,5.,250,0.,5.);
-#endif
+  TH2D *recoVsGenChargedJetAreaHist = nullptr;
+  if (useNewEDM) {
+    recoVsGenChargedJetAreaHist = new TH2D("recoVsGenChargedJetArea","",250,0.,5.,250,0.,5.);
+  }
   TH2D *recoVsGenChargedJetEHist = new TH2D("recoVsGenChargedJetE","",100,0.,100.,100,0.,100.);
   TH2D *recoVsGenChargedJetENoDRHist = new TH2D("recoVsGenChargedJetENoDRHist","",100,0.,100.,100,0.,100.);
   TH2D *recoVsGenChargedJetENoDupHist = new TH2D("recoVsGenChargedJetENoDup","",100,0.,100.,100,0.,100.);
@@ -267,10 +305,10 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
 	recoChargedJetEHist->Fill(recoNRG[i]);
 	if(ECut) recoChargedJetEtaECutHist->Fill(jetMom.PseudoRapidity());
 	recoChargedJetEvsEtaHist->Fill(jetMom.PseudoRapidity(),recoNRG[i]);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-        if(ECut) recoChargedJetAreaECutHist->Fill(recoArea[i]);
-        recoChargedJetEvsAreaHist->Fill(recoArea[i],recoNRG[i]);
-#endif
+        if(useNewEDM) {
+          if(ECut) recoChargedJetAreaECutHist->Fill(recoArea[i]);
+          recoChargedJetEvsAreaHist->Fill(recoArea[i],recoNRG[i]);
+        }
 	if(ECut) recoChargedJetPhiVsEtaECutHist->Fill(jetMom.PseudoRapidity(),jetMom.Phi());
 
 	// Find Jets with Electrons
@@ -352,10 +390,10 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
 	    recoChargedJetENoElecHist->Fill(recoNRG[i]);
 	    if(ECut) recoChargedJetEtaECutNoElecHist->Fill(jetMom.PseudoRapidity());
 	    recoChargedJetEvsEtaNoElecHist->Fill(jetMom.PseudoRapidity(),recoNRG[i]);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-            if(ECut) recoChargedJetAreaECutNoElecHist->Fill(recoArea[i]);
-            recoChargedJetEvsAreaNoElecHist->Fill(recoArea[i],recoNRG[i]);
-#endif
+            if(useNewEDM) {
+              if(ECut) recoChargedJetAreaECutNoElecHist->Fill(recoArea[i]);
+              recoChargedJetEvsAreaNoElecHist->Fill(recoArea[i],recoNRG[i]);
+            }
 	    if(ECut) recoChargedJetPhiVsEtaECutNoElecHist->Fill(jetMom.PseudoRapidity(),jetMom.Phi());
 
 	    if(ECut) numRecoChargedJetsNoElec++; 
@@ -386,10 +424,10 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
 	genChargedJetEHist->Fill(genNRG[i]);
 	if(ECut) genChargedJetEtaECutHist->Fill(jetMom.PseudoRapidity());
 	genChargedJetEvsEtaHist->Fill(jetMom.PseudoRapidity(),genNRG[i]);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-        if(ECut) genChargedJetAreaECutHist->Fill(genArea[i]);
-        genChargedJetEvsAreaHist->Fill(genArea[i],genNRG[i]);
-#endif
+        if(useNewEDM) {
+          if(ECut) genChargedJetAreaECutHist->Fill(genArea[i]);
+          genChargedJetEvsAreaHist->Fill(genArea[i],genNRG[i]);
+        }
 	if(ECut) genChargedJetPhiVsEtaECutHist->Fill(jetMom.PseudoRapidity(),jetMom.Phi());
 
 	// Find Jets with Electrons
@@ -456,10 +494,10 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
 	    genChargedJetENoElecHist->Fill(genNRG[i]);
 	    if(ECut) genChargedJetEtaECutNoElecHist->Fill(jetMom.PseudoRapidity());
 	    genChargedJetEvsEtaNoElecHist->Fill(jetMom.PseudoRapidity(),genNRG[i]);
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-            if(ECut) genChargedJetAreaECutNoElecHist->Fill(genArea[i]);
-            genChargedJetEvsAreaHist->Fill(genArea[i],genNRG[i]);
-#endif
+            if (useNewEDM) {
+              if(ECut) genChargedJetAreaECutNoElecHist->Fill(genArea[i]);
+              genChargedJetEvsAreaHist->Fill(genArea[i],genNRG[i]);
+            }
 	    if(ECut) genChargedJetPhiVsEtaECutNoElecHist->Fill(jetMom.PseudoRapidity(),jetMom.Phi());
 
 	    if(ECut) numGenChargedJetsNoElec++; 
@@ -545,9 +583,9 @@ const int seabornBlue = TColor::GetColor(100, 149, 237);
 	      {
 		recoVsGenChargedJetEtaHist->Fill(jetMom.PseudoRapidity(),recoMatchMom.PseudoRapidity());
 		recoVsGenChargedJetPhiHist->Fill(jetMom.Phi(),recoMatchMom.Phi());
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
-                recoVsGenChargedJetAreaHist->Fill(genArea[i],recoArea[minIndex]);
-#endif
+                if(useNewEDM) {
+                  recoVsGenChargedJetAreaHist->Fill(genArea[i],recoArea[minIndex]);
+                }
 		recoVsGenChargedJetEHist->Fill(genNRG[i],recoNRG[minIndex]);
 		
 		double jetERes = (recoNRG[minIndex] - genNRG[i])/genNRG[i];
@@ -685,31 +723,31 @@ legend3->Draw();
   if(PRINT) c3->Print((results_path+"/recoJetEta.png").c_str()); // Eta spectrum of reconstructed jets with energy > 5 GeV
     delete c3;
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
   // Reco Area
-  TCanvas *c3_1 = new TCanvas("c3_1","Reco Jet Area",800,600);
-  c3_1->Clear();
-  c3_1->Divide(1,1);
+  if(useNewEDM) {
+    TCanvas *c3_1 = new TCanvas("c3_1","Reco Jet Area",800,600);
+    c3_1->Clear();
+    c3_1->Divide(1,1);
 
-  c3_1->cd(1);
-  recoChargedJetAreaECutHist->Draw("HIST");
-  recoChargedJetAreaECutNoElecHist->SetLineColor(seabornRed);
-  recoChargedJetAreaECutNoElecHist->Draw("HISTSAME");
+    c3_1->cd(1);
+    recoChargedJetAreaECutHist->Draw("HIST");
+    recoChargedJetAreaECutNoElecHist->SetLineColor(seabornRed);
+    recoChargedJetAreaECutNoElecHist->Draw("HISTSAME");
 
-  recoChargedJetAreaECutHist->SetLineWidth(2);
-  recoChargedJetAreaECutNoElecHist->SetLineWidth(2);
-  recoChargedJetAreaECutHist->SetTitle("Reconstructed Jet Area (E > 5);Area");
+    recoChargedJetAreaECutHist->SetLineWidth(2);
+    recoChargedJetAreaECutNoElecHist->SetLineWidth(2);
+    recoChargedJetAreaECutHist->SetTitle("Reconstructed Jet Area (E > 5);Area");
 
-//add legend
-TLegend *legend3_1 = new TLegend(0.7, 0.7, 0.9, 0.9); // Adjust the coordinates as needed
-legend3_1->AddEntry(recoChargedJetAreaECutHist, "With Electrons", "l");
-legend3_1->AddEntry(recoChargedJetAreaECutNoElecHist, "No Electrons", "l");
-legend3_1->Draw();
+    //add legend
+    TLegend *legend3_1 = new TLegend(0.7, 0.7, 0.9, 0.9); // Adjust the coordinates as needed
+    legend3_1->AddEntry(recoChargedJetAreaECutHist, "With Electrons", "l");
+    legend3_1->AddEntry(recoChargedJetAreaECutNoElecHist, "No Electrons", "l");
+    legend3_1->Draw();
 
-  gPad->SetLogy();
-  if(PRINT) c3_1->Print((results_path+"/recoJetArea.png").c_str()); // Area spectrum of reconstructed jets with energy > 5 GeV
-    delete c3_1;
-#endif
+    gPad->SetLogy();
+    if(PRINT) c3_1->Print((results_path+"/recoJetArea.png").c_str()); // Area spectrum of reconstructed jets with energy > 5 GeV
+      delete c3_1;
+   }
 
   // Reco E Vs Eta
   TCanvas *c4 = new TCanvas("c4","Reco Jet E Vs Eta",800,600);
@@ -722,18 +760,18 @@ legend3_1->Draw();
   gPad->SetLogz();
   if(PRINT) c4->Print((results_path+"/recoJetEnergyvsEta.png").c_str()); // Energy vs eta of reconstructed jets
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
   // Reco E Vs Area
-  TCanvas *c4_1 = new TCanvas("c4_1","Reco Jet E Vs Area",800,600);
-  c4_1->Clear();
-  c4_1->Divide(1,1);
+  if (useNewEDM) {
+    TCanvas *c4_1 = new TCanvas("c4_1","Reco Jet E Vs Area",800,600);
+    c4_1->Clear();
+    c4_1->Divide(1,1);
 
-  c4_1->cd(1);
-  recoChargedJetEvsAreaHist->Draw("COLZ");
-  recoChargedJetEvsAreaHist->SetTitle("Reconstructed Jet Energy Vs Area;Area;Energy [GeV]");
-  gPad->SetLogz();
-  if(PRINT) c4_1->Print((results_path+"/recoJetEnergyvsArea.png").c_str()); // Energy vs area of reconstructed jets
-#endif
+    c4_1->cd(1);
+    recoChargedJetEvsAreaHist->Draw("COLZ");
+    recoChargedJetEvsAreaHist->SetTitle("Reconstructed Jet Energy Vs Area;Area;Energy [GeV]");
+    gPad->SetLogz();
+    if(PRINT) c4_1->Print((results_path+"/recoJetEnergyvsArea.png").c_str()); // Energy vs area of reconstructed jets
+  }
 
   // Reco Phi Vs Eta
   TCanvas *c5 = new TCanvas("c5","Reco Jet Phi Vs Eta",800,600);
@@ -961,30 +999,30 @@ legend6->Draw();
   gPad->SetLogy();
   if(PRINT) c18->Print((results_path+"/genJetEta.png").c_str()); // Eta spectrum of generator jets with energy > 5 GeV
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
   // Gen Area
-  TCanvas *c18_1 = new TCanvas("c18_1","Gen Jet Area",800,600);
-  c18_1->Clear();
-  c18_1->Divide(1,1);
+  if(useNewEDM) {
+    TCanvas *c18_1 = new TCanvas("c18_1","Gen Jet Area",800,600);
+    c18_1->Clear();
+    c18_1->Divide(1,1);
 
-  c18_1->cd(1);
-  genChargedJetAreaECutHist->Draw("HIST");
-  genChargedJetAreaECutNoElecHist->SetLineColor(seabornRed);
-  genChargedJetAreaECutNoElecHist->Draw("HISTSAME");
+    c18_1->cd(1);
+    genChargedJetAreaECutHist->Draw("HIST");
+    genChargedJetAreaECutNoElecHist->SetLineColor(seabornRed);
+    genChargedJetAreaECutNoElecHist->Draw("HISTSAME");
 
-  genChargedJetAreaECutHist->SetLineWidth(2);
-  genChargedJetAreaECutNoElecHist->SetLineWidth(2);
+    genChargedJetAreaECutHist->SetLineWidth(2);
+    genChargedJetAreaECutNoElecHist->SetLineWidth(2);
 
-  genChargedJetAreaECutHist->SetTitle("Generator Jet Area (E > 5);Area");
+    genChargedJetAreaECutHist->SetTitle("Generator Jet Area (E > 5);Area");
 
-  TLegend *legend18_1 = new TLegend(0.7, 0.7, 0.9, 0.9); // Adjust the coordinates as needed
-  legend18_1->AddEntry(genChargedJetAreaECutHist, "With Electrons", "l");
-  legend18_1->AddEntry(genChargedJetAreaECutNoElecHist, "No Electrons", "l");
-  legend18_1->Draw();
+    TLegend *legend18_1 = new TLegend(0.7, 0.7, 0.9, 0.9); // Adjust the coordinates as needed
+    legend18_1->AddEntry(genChargedJetAreaECutHist, "With Electrons", "l");
+    legend18_1->AddEntry(genChargedJetAreaECutNoElecHist, "No Electrons", "l");
+    legend18_1->Draw();
 
-  gPad->SetLogy();
-  if(PRINT) c18_1->Print((results_path+"/genJetArea.png").c_str()); // Area spectrum of generator jets with energy > 5 GeV
-#endif
+    gPad->SetLogy();
+    if(PRINT) c18_1->Print((results_path+"/genJetArea.png").c_str()); // Area spectrum of generator jets with energy > 5 GeV
+  }
 
   // Gen E Vs Eta
   TCanvas *c19 = new TCanvas("c19","Gen Jet E Vs Eta",800,600);
@@ -997,18 +1035,18 @@ legend6->Draw();
   gPad->SetLogz();
   if(PRINT) c19->Print((results_path+"/genJetEnergyvsEta.png").c_str()); // Energy vs eta of generator jets
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
   // Gen E Vs Area
-  TCanvas *c19_1 = new TCanvas("c19_1","Gen Jet E Vs Area",800,600);
-  c19_1->Clear();
-  c19_1->Divide(1,1);
+  if(useNewEDM) {
+    TCanvas *c19_1 = new TCanvas("c19_1","Gen Jet E Vs Area",800,600);
+    c19_1->Clear();
+    c19_1->Divide(1,1);
 
-  c19_1->cd(1);
-  genChargedJetEvsAreaHist->Draw("COLZ");
-  genChargedJetEvsAreaHist->SetTitle("Generator Jet Energy Vs Area;Area;Energy [GeV]");
-  gPad->SetLogz();
-  if(PRINT) c19_1->Print((results_path+"/genJetEnergyvsArea.png").c_str()); // Energy vs area of generator jets
-#endif
+    c19_1->cd(1);
+    genChargedJetEvsAreaHist->Draw("COLZ");
+    genChargedJetEvsAreaHist->SetTitle("Generator Jet Energy Vs Area;Area;Energy [GeV]");
+    gPad->SetLogz();
+    if(PRINT) c19_1->Print((results_path+"/genJetEnergyvsArea.png").c_str()); // Energy vs area of generator jets
+  }
 
   // Gen Phi Vs Eta
   TCanvas *c20 = new TCanvas("c20","Gen Jet Phi Vs Eta",800,600);
@@ -1205,18 +1243,18 @@ legend6->Draw();
   gPad->SetLogz();
   if(PRINT) c33->Print((results_path+"/matchedRecoVsGenJetPhi.png").c_str()); // Matched reconstructed vs generator jet phi
 
-#if EDM4EIC_BUILD_VERSION >= EDM4EIC_VERSION(8,9,0)
   // Matched Reco Vs Gen Area
-  TCanvas *c33_1 = new TCanvas("c33_1","Reco Vs Gen Area",800,600);
-  c33_1->Clear();
-  c33_1->Divide(1,1);
+  if(useNewEDM) {
+    TCanvas *c33_1 = new TCanvas("c33_1","Reco Vs Gen Area",800,600);
+    c33_1->Clear();
+    c33_1->Divide(1,1);
 
-  c33_1->cd(1);
-  recoVsGenChargedJetAreaHist->Draw("COLZ");
-  recoVsGenChargedJetAreaHist->SetTitle("Reconstructed Vs Generator Jet Area;Gen Area;Reco Area");
-  gPad->SetLogz();
-  if(PRINT) c33_1->Print((results_path+"/matchedRecoVsGenJetArea.png").c_str()); // Matched reconstructed vs generator jet area
-#endif
+    c33_1->cd(1);
+    recoVsGenChargedJetAreaHist->Draw("COLZ");
+    recoVsGenChargedJetAreaHist->SetTitle("Reconstructed Vs Generator Jet Area;Gen Area;Reco Area");
+    gPad->SetLogz();
+    if(PRINT) c33_1->Print((results_path+"/matchedRecoVsGenJetArea.png").c_str()); // Matched reconstructed vs generator jet area
+  }
 
   // Matched Reco Vs Gen Energy
   TCanvas *c34 = new TCanvas("c34","Reco Vs Gen Energy",800,600);
@@ -1480,4 +1518,5 @@ legend->Draw();
 delete mychain;
 
   return 0;
+
 }


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This PR reaps what was sown in #107: I didn't test the changes locally and didn't catch a smattering of typos. While testing the macro for the Validation WG, I also found out that the version guards are insufficient: the 26.05.0 campaign used the EDM4eic version with `edm4eic::Jet` in it, _but_ was still outputting jets as `edm4eic::ReconstructedParticle`. This PR fixes this by adding an explicit check on whether or not the area branches exist.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [ ] Medium
- [x] Low

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.